### PR TITLE
fix http://repo.kali.org 403

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM debian:jessie
 MAINTAINER Nitrax <nitrax@lokisec.fr>
 
 # Adding Kali repository
-RUN echo 'deb http://repo.kali.org/kali kali-rolling main non-free contrib' >> /etc/apt/sources.list
-RUN echo 'deb-src http://repo.kali.org/kali kali-rolling main non-free contrib' >> /etc/apt/sources.list
+RUN echo 'deb http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list
+RUN echo 'deb-src http://http.kali.org/kali kali-rolling main contrib non-free' >> /etc/apt/sources.list
 
 RUN gpg --keyserver pgpkeys.mit.edu --recv-key  ED444FF07D8D0BF6
 RUN gpg -a --export ED444FF07D8D0BF6 | apt-key add -


### PR DESCRIPTION
The `http://repo.kali.org/kali` repo gives a 403 (see log below), this pull request changes the repo to `http://http.kali.org/kali` which works.

```console
et:1 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://repo.kali.org kali-rolling InRelease
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [145 kB]
Ign http://repo.kali.org kali-rolling Release.gpg
Get:3 http://deb.debian.org jessie Release.gpg [2420 B]
Ign http://repo.kali.org kali-rolling Release
Get:4 http://deb.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [636 kB]
Err http://repo.kali.org kali-rolling/main Sources
  403  Forbidden
Err http://repo.kali.org kali-rolling/non-free Sources
  403  Forbidden
Err http://repo.kali.org kali-rolling/contrib Sources
  403  Forbidden
Err http://repo.kali.org kali-rolling/main amd64 Packages
  403  Forbidden
Get:6 http://deb.debian.org jessie-updates/main amd64 Packages [23.0 kB]
Get:7 http://deb.debian.org jessie/main amd64 Packages [9098 kB]
Err http://repo.kali.org kali-rolling/non-free amd64 Packages
  403  Forbidden
Err http://repo.kali.org kali-rolling/contrib amd64 Packages
  403  Forbidden
Fetched 10.1 MB in 19s (515 kB/s)
W: Failed to fetch http://repo.kali.org/kali/dists/kali-rolling/main/source/Sources  403  Forbidden

W: Failed to fetch http://repo.kali.org/kali/dists/kali-rolling/non-free/source/Sources  403  Forbidden
```